### PR TITLE
Add Personae GCP buckets

### DIFF
--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -1,12 +1,12 @@
 export const DEFAULT_EFF_ECDSA_WITNESS_GEN_WASM =
-  "https://storage.googleapis.com/proving_keys/eff_ecdsa/eff_ecdsa.wasm";
+  "https://storage.googleapis.com/personae-proving_keys/eff_ecdsa/eff_ecdsa.wasm";
 export const DEFAULT_EFF_ECDSA_CIRCUIT =
-  "https://storage.googleapis.com/proving_keys/eff_ecdsa/eff_ecdsa.circuit";
+  "https://storage.googleapis.com/personae-proving_keys/eff_ecdsa/eff_ecdsa.circuit";
 export const DEFAULT_SPARTAN_WASM =
-  "https://storage.googleapis.com/proving_keys/spartan_wasm_bg.wasm";
+  "https://storage.googleapis.com/personae-proving_keys/spartan_wasm_bg.wasm";
 
 export const DEFAULT_MEMBERSHIP_WITNESS_GEN_WASM =
-  "https://storage.googleapis.com/proving_keys/membership/membership.wasm";
+  "https://storage.googleapis.com/personae-proving-keys/spartan_wasm_bg.wasm";
 
 export const DEFAULT_MEMBERSHIP_CIRCUIT =
-  "https://storage.googleapis.com/proving_keys/membership/membership.circuit";
+  "https://storage.googleapis.com/personae-proving_keys/membership/membership.circuit";


### PR DESCRIPTION
1. created dedicated Personae Labs GCP buckets (not tracked in this repo) 
2. changed default URLs for proving artifacts in ts lib to use the new buckets